### PR TITLE
account for features with common root name

### DIFF
--- a/category_update.py
+++ b/category_update.py
@@ -50,7 +50,7 @@ def get_versions(features, path):
 
     for name in contents:
         for feature in features:
-            if feature in name:
+            if feature + '_' in name:
                 archive = ZipFile(path + '/' + name + '.jar')
                 xml = archive.read('feature.xml')
                 root = ElemTree.fromstring(xml)


### PR DESCRIPTION
When checking if a feature is matching an existing folder or jar account for features with common root names, so that only the version of the correct features is used.
